### PR TITLE
Fix broken power ups list loading

### DIFF
--- a/lib/persistant_game_state.dart
+++ b/lib/persistant_game_state.dart
@@ -11,7 +11,7 @@ class PersistantGameState {
       Map data = decoder.convert(json);
 
       coins = data['coins'];
-      _powerupLevels = data['powerUpLevels'];
+      _powerupLevels = data['powerUpLevels'].cast<int>();
       _currentStartingLevel = data['currentStartingLevel'];
       maxStartingLevel = data['maxStartingLevel'];
       laserLevel = data['laserLevel'];


### PR DESCRIPTION
Fixes the error `type 'List<dynamic>' is not a subtype of type 'List<int>'` when loading back the power ups list from JSON.